### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1
+  - 2.2.2
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
Fix travis error caused by using ruby-v2.1
ActiveSupport require ruby-v2.2.2