### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: ruby
-cache: bundler
+
+# https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/
+cache:
+  bundler: true
+  directories:
+  - $TRAVIS_BUILD_DIR/tmp/.htmlproofer #https://github.com/gjtorikian/html-proofer/issues/381
 
 rvm:
   -  2.5.7
@@ -8,6 +13,11 @@ rvm:
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev # required to avoid SSL errors on html-proofer
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 
 test:
 	bundle exec htmlproofer ./_site --allow-hash-href --assume-extension \
-	--check-favicon --check-html --check-opengraph --only-4xx
+	--check-favicon --check-html --check-opengraph --timeframe 4w
 
 serve:
 	bundle exec jekyll serve --drafts --future --unpublished


### PR DESCRIPTION
Cache bundler and html-proofer
Add `libcurl4-openssl-dev` to avoid SSL error