### PR TITLE
Update _config.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :jekyll_plugins do
     gem 'jekyll-remote-theme'
     #gem 'jekyll-redirect-from'
     #gem 'jekyll-github-metadata'
-    gem 'jekyll-commonmark'
+    gem 'jekyll-commonmark-ghpages'
     gem 'jekyll-gist'
     gem 'jekyll-mentions'
     gem 'jekyll-relative-links'

--- a/_config.yml
+++ b/_config.yml
@@ -131,7 +131,7 @@ plugins:
   - jekyll-remote-theme
 #  - jekyll-redirect-from
 #  - jekyll-github-metadata
-  - jekyll-commonmark
+  - jekyll-commonmark-ghpages
 #  - jekyll-gist
   - jekyll-mentions
   - jekyll-relative-links
@@ -143,7 +143,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
 
-markdown: CommonMark
+markdown: CommonMarkGhPages
 
 commonmark:
   options: [SMART, FOOTNOTES, UNSAFE]

--- a/_config.yml
+++ b/_config.yml
@@ -148,8 +148,6 @@ markdown: CommonMark
 commonmark:
   options: [SMART, FOOTNOTES, UNSAFE]
   extensions: [table, strikethrough, autolink]
-  render:
-    header_ids: true  # Enable auto-IDs for headings
 
 jekyll-mentions: 'https://twitter.com'
 


### PR DESCRIPTION
In #74 I try to update jekyll-commonmark to generate ids for header (h2-h6), turn out cmark-gfm dont generate it. I already test in #79 if jampack removed generated id, but it doesnt.

Close #74

Everything fixed by change markdown converter to jekyll-commonmark-ghpages.

https://github.com/github/jekyll-commonmark-ghpages/blob/b91af13d404bcd2d3f5c5a13d0cb41bd1e41a1d0/lib/jekyll-commonmark-ghpages.rb#L21-L23

- [x] Build preview

```
// To set schedule
(at)prscheduler dd/MM/yyyyThh:mm GMT+8
```
