### PR TITLE
Update minify-html.js

### DIFF
--- a/minify-html.js
+++ b/minify-html.js
@@ -6,9 +6,10 @@ const minify = require('@minify-html/node');
 const BUILD_DIR = '_site'; 
 
 const cfg = {
+    // https://github.com/wilsonzlin/minify-html/minify-html-nodejs/src/lib.rs#L22-L36
     keep_closing_tags: true,
     keep_html_and_head_opening_tags: true,
-    keep_spaces_between_attributes: true
+    keep_input_type_text_attr: true
 };
 
 function walkDir(dir, callback) {

--- a/minify-html.js
+++ b/minify-html.js
@@ -6,7 +6,7 @@ const minify = require('@minify-html/node');
 const BUILD_DIR = '_site'; 
 
 const cfg = {
-    // https://github.com/wilsonzlin/minify-html/minify-html-nodejs/src/lib.rs#L22-L36
+    // https://github.com/wilsonzlin/minify-html/blob/697c04ac49673ec6f981e7c47e1ad878f8e4f38d/minify-html-nodejs/src/lib.rs#L22-L36
     keep_closing_tags: true,
     keep_html_and_head_opening_tags: true,
     keep_input_type_text_attr: true

--- a/minify-html.js
+++ b/minify-html.js
@@ -6,7 +6,7 @@ const minify = require('@minify-html/node');
 const BUILD_DIR = '_site'; 
 
 const cfg = {
-    // https://github.com/wilsonzlin/minify-html/blob/697c04ac49673ec6f981e7c47e1ad878f8e4f38d/minify-html-nodejs/src/lib.rs#L22-L36
+// Config options: https://docs.rs/minify-html/latest/minify_html/struct.Cfg.html
     keep_closing_tags: true,
     keep_html_and_head_opening_tags: true,
     keep_input_type_text_attr: true


### PR DESCRIPTION
Update minify-html/node config.
- remove keep_spaces_between_attributes. Its doesnt exist.
- Fix broken input on contact page, caused by `type=text` removed by minifier and the input become unstyled.

- [x] Build preview

```
// To set schedule
(at)prscheduler dd/MM/yyyyThh:mm GMT+8
```
